### PR TITLE
Added functional batching and timeout retry mechanisms

### DIFF
--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -247,7 +247,7 @@
             },
             "logLevel": {
               "type": "string",
-              "defaultValue": "INFO",
+              "defaultValue": "DEBUG",
               "allowedValues": [
                 "DEBUG",
                 "INFO",
@@ -308,10 +308,6 @@
                         {
                           "name": "CLIENT_SECRET",
                           "secureValue": "[[parameters('clientSecret')]"
-                        },
-                        {
-                          "name": "WORKERS",
-                          "value": 50
                         },
                         {
                           "name": "LOG_LEVEL",

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -310,6 +310,10 @@
                           "secureValue": "[[parameters('clientSecret')]"
                         },
                         {
+                          "name": "WORKERS",
+                          "value": 50
+                        },
+                        {
                           "name": "LOG_LEVEL",
                           "value": "[[parameters('logLevel')]"
                         }

--- a/load.sh
+++ b/load.sh
@@ -17,6 +17,7 @@ if [ -z $LOAD_FILES ]; then LOAD_FILES=true; else if [ $LOAD_FILES != false ]; t
 if [ -z $LOAD_WORKPRODUCTS ]; then LOAD_WORKPRODUCTS=true; else if [ $LOAD_WORKPRODUCTS != false ]; then LOAD_WORKPRODUCTS=true; fi fi
 if [ -z $KEEP_OPEN ]; then KEEP_OPEN=false; fi
 
+
 if [ -z $1 ]; then
   if [ -z $DATA_PARTITION ]; then
     tput setaf 1; echo "ERROR: Argument \$1 - Data Partition name required." ; tput sgr0
@@ -34,6 +35,9 @@ do
         p) data_partition=${OPTARG};;
     esac
 done
+
+echo "BATCH_SIZE: $BATCH_SIZE"
+echo "WORKERS: $WORKERS"
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 PARENT_DIR=`dirname $SCRIPT_DIR`

--- a/load.sh
+++ b/load.sh
@@ -7,7 +7,7 @@
 usage() { echo "Usage: load.sh <data_partition>" 1>&2; exit 1; }
 
 if [ -z $LOG_LEVEL ]; then LOG_LEVEL="info"; fi
-if [ -z $BATCH_SIZE ]; then BATCH_SIZE=100; fi
+if [ -z $BATCH_SIZE ]; then BATCH_SIZE=25; fi
 if [ -z $PIP_INSTALL ]; then PIP_INSTALL=true; else if [ $PIP_INSTALL != false ]; then PIP_INSTALL=true; fi fi
 if [ -z $CONFIGURE_INI ]; then CONFIGURE_INI=true; else if [ $CONFIGURE_INI != false ]; then CONFIGURE_INI=true; fi fi
 if [ -z $CHECK_LEGAL_TAG ]; then CHECK_LEGAL_TAG=true; else if [ $CHECK_LEGAL_TAG != false ]; then CHECK_LEGAL_TAG=true; fi fi

--- a/src/data_load/load.py
+++ b/src/data_load/load.py
@@ -656,24 +656,6 @@ def get_directory_name(filepath):
     return urllib.parse.quote(dir_name)
 
 
-# def manifest_ingest(is_wpc, batch_size, data_objects, data_type): #kym
-#     batch_objects = []
-#     logger.debug(f"Manifest Ingestion - Splitting data into batches - Full data set size {len(data_objects)}, splitting into batches of {batch_size} records")
-
-#     for i, data_object in enumerate(data_objects):
-#         batch_objects.append(data_object)
-
-#         if len(batch_objects) == batch_size or i == len(data_objects) - 1:
-#             if is_wpc:
-#                 request_data = populate_workflow_request(batch_objects)
-#                 logger.debug(f"Sending Request with WPC data, batch number: {len(batch_objects)}")
-#             else:
-#                 request_data = populate_typed_workflow_request(batch_objects, data_type)
-#                 logger.debug(f"Sending Request with batch number: {len(batch_objects)}")
-
-#             send_request(request_data)
-#             batch_objects = []
-
 def send_batch_request(batch_objects, is_wpc, data_type):
     if is_wpc:
         request_data = populate_workflow_request(batch_objects)
@@ -686,10 +668,10 @@ def send_batch_request(batch_objects, is_wpc, data_type):
 
 def manifest_ingest(is_wpc, batch_size, data_objects, data_type): #kym
     batch_objects = []
-    logger.debug(f"Manifest Ingestion - Splitting data into batches - Full data set size {len(data_objects)}, splitting into batches of {batch_size} records")
     logger.debug(f"Data type: {data_type}, WPC mode: {is_wpc}, data_objects: {data_objects}")
 
     for data_object in data_objects:
+        logger.debug(f"Manifest Ingestion - Splitting data into batches - Full data set size {len(data_object)}, splitting into batches of {batch_size} records")
         if data_type == "MasterData":
             for record in data_object:  # Iterate over the records inside each data_object
                 batch_objects.append(record)

--- a/src/data_load/load.py
+++ b/src/data_load/load.py
@@ -1061,7 +1061,7 @@ def main(argv):
 
         # Execute Action
         success, failed = load_files(a_dir)
-
+        logger.debug(f"Files that are successfully uploaded: {len(success)}")
         # Create Result File
         with open(a_file_name, 'w') as f:
             json.dump(success, f, indent=4)

--- a/src/data_load/load.py
+++ b/src/data_load/load.py
@@ -655,7 +655,7 @@ def manifest_ingest(is_wpc, cur_batch, data_objects, data_type): #kym
     cur_batch = 0
     batch_size = 5
     batch_objects = []
-    logger.debug("Manifest Ingestion - Splitting data into batches - Full data set size {len(data_objects)}, splitting into batches of {batch_size}")
+    logger.debug(f"Manifest Ingestion - Splitting data into batches - Full data set size {len(data_objects)}, splitting into batches of {batch_size}")
     for i, data_object in enumerate(data_objects):
         logger.debug(f"Manifest Ingestion - Current batch size {cur_batch}")
         batch_objects.append(data_object)

--- a/src/data_load/load.py
+++ b/src/data_load/load.py
@@ -575,7 +575,7 @@ def execute_sequence_ingestion(dir_name, ingestion_sequence, batch_size=300):
             manifest_ingest(False, len(batch), batch, data_type)
 
 
-def execute_ingestion(dir_name, batch_size=1, is_wpc=False, file_location_map="", standard_reference=False):
+def execute_ingestion(dir_name, batch_size=1, is_wpc=False, file_location_map="", standard_reference=False): #####
 
     # For all manifest files
     for root, _, files in os.walk(dir_name):
@@ -657,7 +657,7 @@ def manifest_ingest(is_wpc, cur_batch, data_objects, data_type):
         logger.debug(f"Sending Request with WPC data {cur_batch}")
     else:
         request_data = populate_typed_workflow_request(data_objects, data_type)
-        logger.debug(f"Sending Request with batch size {cur_batch}")
+        logger.debug(f"Sending Request with batch size {cur_batch}") ########
 
     send_request(request_data)
     cur_batch = 0
@@ -834,7 +834,7 @@ def populate_typed_workflow_request(data, data_type):
             "manifest": populate_manifest(data, data_type)
         }
     }
-    logger.debug(f"Request to be sent {request}")
+    logger.debug(f"Request to be sent {request}") #####
     return request
 
 

--- a/src/data_load/load.py
+++ b/src/data_load/load.py
@@ -460,9 +460,9 @@ def load_single_file(session, root, file):
         #####################
         # Put BLOB Data
         #####################
-        loggeer.debug(f"Getting blob client")
+        logger.debug(f"Getting blob client")
         blob_client = BlobClient.from_blob_url(signed_url, max_single_put_size=MAX_CHUNK_SIZE * 1024)
-        loggeer.debug(f"Opening file stream for {filepath}")
+        logger.debug(f"Opening file stream for {filepath}")
         with open(filepath, "rb") as file_stream:
             logger.debug(f"Uploading file to blob: {filepath}")
             upload_response = blob_client.upload_blob(file_stream, blob_type="BlockBlob", overwrite=True)

--- a/src/data_load/load.py
+++ b/src/data_load/load.py
@@ -593,13 +593,13 @@ def execute_sequence_ingestion(dir_name, batch_size, ingestion_sequence):
         logger.debug(f"Ingesting objects from file: {filepath_normalized}")
         manifest_ingest(False, batch_size, object_to_ingest, data_type)
 
-def execute_ingestion(dir_name, batch_size, is_wpc=False, file_location_map="", standard_reference=False): #kym
+def execute_ingestion(dir_name, batch_size, is_wpc=False, file_location_map="", standard_reference=False):
     for root, _, files in os.walk(dir_name):
         logger.debug(f"Files list: {files}")
         for file in files:
             data_objects = []
             filepath = os.path.join(root, file)
-            object_to_ingest, data_type = get_object_to_ingest(file_location_map, standard_reference, filepath) #kym
+            object_to_ingest, data_type = get_object_to_ingest(file_location_map, standard_reference, filepath)
 
             if object_to_ingest is None:
                 continue
@@ -610,10 +610,10 @@ def execute_ingestion(dir_name, batch_size, is_wpc=False, file_location_map="", 
             else:
                 data_objects.append(object_to_ingest)
 
-            manifest_ingest(is_wpc, batch_size, data_objects, data_type) #kym
+            manifest_ingest(is_wpc, batch_size, data_objects, data_type)
 
 
-def get_object_to_ingest(file_location_map, standard_reference, filepath): #kym
+def get_object_to_ingest(file_location_map, standard_reference, filepath): 
     logger.debug(f"parsing file for ingestion - {filepath}")
 
     if filepath.endswith(".json"):
@@ -666,7 +666,7 @@ def send_batch_request(batch_objects, is_wpc, data_type):
 
     send_request(request_data)
 
-def manifest_ingest(is_wpc, batch_size, data_objects, data_type): #kym
+def manifest_ingest(is_wpc, batch_size, data_objects, data_type):
     batch_objects = []
     logger.debug(f"Data type: {data_type}, WPC mode: {is_wpc}, data_objects: {data_objects}")
 
@@ -1015,7 +1015,7 @@ def main(argv):
         a_standard_ref = vars_parsed_args.get("standard_reference")
 
         # Execute Action
-        execute_ingestion(a_dir, a_batch_size, a_is_wpc, a_location_map, a_standard_ref) #kym
+        execute_ingestion(a_dir, a_batch_size, a_is_wpc, a_location_map, a_standard_ref)
 
     #####################
     # Action: references

--- a/src/data_load/load.py
+++ b/src/data_load/load.py
@@ -127,12 +127,6 @@ def requests_retry_session(
     allowed_methods=["GET", "PUT", "POST", "DELETE"],
     session=None,
 ):
-    logger.info("Creating a requests retry session")
-    logger.debug(f"Retries: {retries}")
-    logger.debug(f"Backoff factor: {backoff_factor}")
-    logger.debug(f"Status forcelist: {status_forcelist}")
-    logger.debug(f"Allowed methods: {allowed_methods}")
-
     session = session or requests.Session()
     retry = Retry(
         total=retries,
@@ -145,8 +139,6 @@ def requests_retry_session(
     adapter = HTTPAdapter(max_retries=retry)
     session.mount('http://', adapter)
     session.mount('https://', adapter)
-
-    logger.info("Requests retry session created successfully")
     return session
 
 

--- a/src/data_load/load.py
+++ b/src/data_load/load.py
@@ -653,15 +653,15 @@ def get_directory_name(filepath):
 
 def manifest_ingest(is_wpc, cur_batch, data_objects, data_type): #kym
     cur_batch = 0
-    batch_size = 5
+    manifest_batch_size = 100
     batch_objects = []
-    logger.debug(f"Manifest Ingestion - Splitting data into batches - Full data set size {len(data_objects)}, splitting into batches of {batch_size}")
+    logger.debug(f"Manifest Ingestion - Splitting data into batches - Full data set size {len(data_objects)}, splitting into batches of {manifest_batch_size}")
     for i, data_object in enumerate(data_objects):
-        logger.debug(f"Manifest Ingestion - Current batch size {cur_batch}")
         batch_objects.append(data_object)
         cur_batch += 1
 
-        if cur_batch == batch_size or i == len(data_objects) - 1:
+        if cur_batch == manifest_batch_size or i == len(data_objects) - 1:
+            logger.debug(f"Manifest Ingestion - Current batch: {cur_batch}")
             if is_wpc:
                 request_data = populate_workflow_request(batch_objects)
                 logger.debug(f"Sending Request with WPC data {cur_batch}")
@@ -670,9 +670,8 @@ def manifest_ingest(is_wpc, cur_batch, data_objects, data_type): #kym
                 logger.debug(f"Sending Request with batch size {cur_batch}") #kym
 
             send_request(request_data)
-            cur_batch = 0
             batch_objects = []
-
+    cur_batch = 0
     return cur_batch, batch_objects
 
 def status_check():

--- a/src/data_load/load.py
+++ b/src/data_load/load.py
@@ -470,12 +470,12 @@ def load_single_file(session, root, file):
         #####################
         metadata_body = json.dumps(
             populate_file_metadata(file_source, file, dir_name))
-        metadata_response = session.post(
+        metadata_response = session.post( ####### FAILING!
             FILE_URL + "/files/metadata", metadata_body, headers=headers)
-
+        logger.info(f"Metadata Body for {filepath} : {metadata_body}")
         if metadata_response.status_code != 201:
             logger.error(
-                f"/files/metadata failed for {filepath} with response {metadata_response}")
+                f"/files/metadata failed for {filepath} with response {metadata_response.status_code} and body {metadata_response.text}")
             return FILE_UPLOAD_FAILED, filepath
 
         #####################

--- a/src/data_load/load.py
+++ b/src/data_load/load.py
@@ -133,7 +133,11 @@ def requests_retry_session(
 
     def request_with_timeout(method, url, **kwargs):
         kwargs.setdefault('timeout', timeout)  # Set default timeout if not provided
-        return original_request(method, url, **kwargs)
+        try:
+            return original_request(method, url, **kwargs)
+        except requests.exceptions.Timeout as e:
+            logger.error(f"Request to {url} timed out: {e}")
+            raise
 
     session.request = request_with_timeout
 


### PR DESCRIPTION
The batching wasn't working correctly and we now need to batch the number of records we send in each manifest ingest, or the service will complain the request was too large. We also were hanging when calling the storage api, so I added in a timeout and retry logic.