### PR TITLE
Fix Data Domain in dataload.ini file

### DIFF
--- a/load.sh
+++ b/load.sh
@@ -27,7 +27,7 @@ else
   DATA_PARTITION=$1
 fi
 
-if [ -z $DATA_DOMAIN ]; then DATA_DOMAIN='dataservices.energy'; fi
+if [ -z $DOMAIN ]; then DOMAIN='dataservices.energy'; fi
 
 while getopts p: flag
 do
@@ -73,7 +73,7 @@ function ConfigureIni() {
     sed -i -e "s/<LEGAL_TAG>/${LEGAL_TAG}/g" "$SCRIPT_DIR/output/dataload.ini"
     sed -i -e "s/<DATA_PARTITION>/${DATA_PARTITION}/g" "$SCRIPT_DIR/output/dataload.ini"
     sed -i -e "s?<LOGIN_ENDPOINT>?${LOGIN_ENDPOINT}?g" "$SCRIPT_DIR/output/dataload.ini"
-    sed -i -e "s?<DOMAIN>?${DATA_DOMAIN}?g" "$SCRIPT_DIR/output/dataload.ini"
+    sed -i -e "s?<DOMAIN>?${DOMAIN}?g" "$SCRIPT_DIR/output/dataload.ini"
     echo "-----"
   else
     echo "Config dataload.ini - Bypassed."


### PR DESCRIPTION
I have noticed when deploying the `osdu-data-load-tno` template spec that the given Data Domain is not properly reflected in the `dataload.ini` file.

For example if you choose `contoso.com` as Data Domain when trying to deploy to an OSDU community Edition,
![image](https://github.com/user-attachments/assets/c6a4a8ea-c00b-468c-8595-6025d28f58df)
then the `dataload.ini`  file in the output folder still use the `acl_owner` and `acl_viewer` are still using the default `dataservices.energy` instead of `contoso.com`
```
acl_viewer = data.default.viewers@opendes.dataservices.energy
acl_owner = data.default.owners@opendes.dataservices.energy
```