### PR TITLE
Add explicit write permission

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,6 +8,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       -  uses: actions/checkout@v2
       - name: Bicep Build


### PR DESCRIPTION
Default permissions changed in GitHub and the action is failing with "remote: Permission to Azure/osdu-data-load-tno.git denied to github-actions[bot]."

Ex: https://github.com/Azure/osdu-data-load-tno/actions/runs/12201706806/job/34040698969